### PR TITLE
View mode on node template

### DIFF
--- a/sites/all/themes/creative_responsive_theme/overrides.css
+++ b/sites/all/themes/creative_responsive_theme/overrides.css
@@ -50,6 +50,9 @@
      element instead of using a floppy/unreliable float property which introduces
      other document/element flow issues */
   position: relative;
+  display: inline-block;
+  float: right;
+  width: auto;
 }
 
 /* This is why using IDs is a bad idea - it's hard to override using CSS classes */

--- a/sites/all/themes/creative_responsive_theme/template.php
+++ b/sites/all/themes/creative_responsive_theme/template.php
@@ -91,6 +91,9 @@ function creative_responsive_theme_preprocess_node(&$variables) {
   if ($variables['view_mode'] == 'full' && node_is_page($variables['node'])) {
     $variables['classes_array'][] = 'node-full';
   }
+
+  // Add the current view mode to the classes
+  $variables['classes_array'][] = $variables['view_mode'];
 }
 
 function creative_responsive_theme_page_alter($page) {

--- a/sites/all/themes/creative_responsive_theme/templates/node.tpl.php
+++ b/sites/all/themes/creative_responsive_theme/templates/node.tpl.php
@@ -85,7 +85,7 @@
       <h2 class="title" <?php print $title_attributes; ?>><a href="<?php print $node_url; ?>"><?php print $title; ?></a></h2>
       <?php endif; ?>
       <?php print render($title_suffix); ?>
-  
+
       <?php if ($display_submitted): ?>
         <span class="submitted"><?php print $submitted; ?></span>
       <?php endif; ?>
@@ -94,7 +94,7 @@
       </header>
   <?php endif; ?>
 
-  <div class="content <?php print $classes_array['1']; ?>"<?php print $content_attributes; ?>>
+  <div class="content <?php print implode(' ', $classes_array); ?>"<?php print $content_attributes; ?>>
     <?php
       // Hide comments, tags, and links now so that we can render them later.
       hide($content['comments']);


### PR DESCRIPTION
I can see why this broke - it's because the CSS rules will apply to any instance of the accommodation node regardless of its view mode. I've added some preprocess code which adds the current view mode so if you're styling the full view mode of the accommodation node only... something like:

``` css
.node-accommodation.full .field-name-field-hotel-logo {
  width: 30%;
  float: left;
}

.node-accommodation.full .field-name-field-map-embed {
  width: 60%;
  float: right;
}
```

That means any that are in teaser display mode won't be affected because the CSS selectors above won't match those.
